### PR TITLE
Add missing ABIEncoderV2 pragma in ColonyStorage.sol

### DIFF
--- a/contracts/ColonyStorage.sol
+++ b/contracts/ColonyStorage.sol
@@ -16,6 +16,7 @@
 */
 
 pragma solidity >=0.5.8 <0.8.0;
+pragma experimental ABIEncoderV2;
 
 import "../lib/dappsys/math.sol";
 import "./ERC20Extended.sol";


### PR DESCRIPTION
This is basically a port of my fix submitted to the JoinColony repo (https://github.com/JoinColony/colonyNetwork/pull/879) to the `develop_070` branch that we're using in CI.

Tests in #9835 won't pass without this change.