### PR TITLE
Fix EtherRouter fallback() incorrectly converted to receive() in 0.6.0 upgrade

### DIFF
--- a/contracts/EtherRouter.sol
+++ b/contracts/EtherRouter.sol
@@ -24,7 +24,7 @@ import "../lib/dappsys/auth.sol";
 contract EtherRouter is DSAuth {
   Resolver public resolver;
 
-  receive() external payable {
+  fallback() external payable {
     if (msg.sig == 0) {
       return;
     }


### PR DESCRIPTION
The fallback function has been incorrectly replaced with `receive()` rather than `fallback()` when we were upgrading the Colony contract to 0.6.0: https://github.com/solidity-external-tests/colonyNetwork/commit/d94f21c310fa58da87baaed79e54bddee335054d. This broke the `EtherRouter` proxy but since we don't execute external tests (only compile them), it went unnoticed.

This bug does not exist in the upstream [colonyNetwork repository](https://github.com/JoinColony/colonyNetwork). They skipped 0.6 and in the recent upgrade to 0.7 the fallback has been updated correctly: https://github.com/JoinColony/colonyNetwork/commit/1c3b642dcef1672849c191ac9d58bb25e944ba7e.

This bug is a direct cause of migration failure in [this `t_ems_ext_test_colony` run](https://app.circleci.com/pipelines/github/ethereum/solidity/10690/workflows/8b848e1b-0544-4f49-9ff4-dd838c4f80ed/jobs/519154) in Solidity CI:
```
4_setup_colony_version_resolver.js
==================================

Error: Error: StatusError: Transaction: 0xbc57b51cd69b6d813f9350752c1888032eb7fb80448d12a83a380c30ea62c5d3 exited with an error (status 0). 
     Please check that the transaction:
     - satisfies all conditions set by Solidity `require` statements.
     - does not trigger a Solidity `revert` statement.

    at Object.run (/tmp/tmp.AscJCkqbin/ext/node_modules/truffle/build/webpack:/packages/migrate/index.js:96:1)
    at process._tickCallback (internal/process/next_tick.js:68:7)
```